### PR TITLE
Set end date to 1 hour in the future

### DIFF
--- a/app/Http/Livewire/Loan/Loans.php
+++ b/app/Http/Livewire/Loan/Loans.php
@@ -74,13 +74,18 @@ class Loans extends Component
         $this->resetPage();
     }
 
-    public function makeBlankLoan()
+    public function makeBlankLoan($clearDateTime = false)
     {
         $this->editing = Loan::make();
+        $this->editing->start_date_time = Carbon::now();
+        $this->editing->end_date_time = Carbon::now()->add(1, 'hour');
         $equipment_id = null;
         $this->emptyCart();
         $this->iteration ++;
-        $this->dispatchBrowserEvent('datetime-clear');
+
+        if ($clearDateTime) {
+            $this->dispatchBrowserEvent('datetime-clear');
+        }
     }
 
     public function deleteSelected()
@@ -105,10 +110,13 @@ class Loans extends Component
         if ($this->editing->getKey()){
         }
 
-        $this->makeBlankLoan();
+        $this->makeBlankLoan(true);
 
         $this->modalType = "Create";
         $this->emit('showModal', 'create');
+
+        // Clear any previous error
+        $this->updated();
     }
 
     public function edit(Loan $loan)
@@ -135,6 +143,9 @@ class Loans extends Component
         //Populate equipment dropdown
         $this->getBookableEquipment($this->editing->start_date_time, $this->editing->end_date_time);
         $this->iteration ++;
+
+        // Clear any previous error
+        $this->updated();
     }
 
     public function save()

--- a/app/Http/Livewire/Loan/Loans.php
+++ b/app/Http/Livewire/Loan/Loans.php
@@ -115,7 +115,7 @@ class Loans extends Component
         $this->modalType = "Create";
         $this->emit('showModal', 'create');
 
-        // Clear any previous error
+        // Clear datetime errors from previous modals
         $this->updated();
     }
 
@@ -144,7 +144,7 @@ class Loans extends Component
         $this->getBookableEquipment($this->editing->start_date_time, $this->editing->end_date_time);
         $this->iteration ++;
 
-        // Clear any previous error
+        // Clear datetime errors from previous modals
         $this->updated();
     }
 

--- a/app/Http/Livewire/Setup/Setups.php
+++ b/app/Http/Livewire/Setup/Setups.php
@@ -79,14 +79,20 @@ class Setups extends Component
         $this->resetPage();
     }
 
-    public function makeBlankSetup()
+    public function makeBlankSetup($clearDateTime = false)
     {
         #We must preload an empty loan so @entangle doesnt error
         $this->editing = Setup::make()->setRelation('loan', Loan::make());
+        $this->editing->loan->start_date_time = Carbon::now();
+        $this->editing->loan->end_date_time = Carbon::now()->add(1, 'hour');
 
         $equipment_id = null;
         $this->emptyCart();
         $this->iteration ++;
+
+        if ($clearDateTime) {
+            $this->dispatchBrowserEvent('datetime-clear');
+        }
     }
 
     public function deleteSelected()
@@ -110,10 +116,13 @@ class Setups extends Component
         //I Removed for now as it wasen't resetting properly between editing/creating etc
         if ($this->editing->getKey()){
         }
-        $this->makeBlankSetup();
+        $this->makeBlankSetup(true);
 
         $this->modalType = "Create";
         $this->emit('showModal', 'create');
+
+        // Clear datetime errors from previous modals
+        $this->updated();
     }
 
     public function edit(Setup $setup)
@@ -140,12 +149,14 @@ class Setups extends Component
         //Populate equipment dropdown
         $this->getBookableEquipment($this->editing->loan->start_date_time, $this->editing->loan->end_date_time);
         $this->iteration ++;
+
+        // Clear datetime errors from previous modals
+        $this->updated();
     }
 
     public function save()
     {
         $this->validate();
-
 
         $this->editing->loan->start_date_time = carbon::parse($this->editing->loan->start_date_time);
         $this->editing->loan->end_date_time = carbon::parse($this->editing->loan->end_date_time);

--- a/resources/views/components/input/datetime.blade.php
+++ b/resources/views/components/input/datetime.blade.php
@@ -9,7 +9,7 @@
       pickers['{{ $id }}'] = new tempusDominus.TempusDominus(document.getElementById('picker{{ $id }}'), {display: {sideBySide: true,}});
       pickers['{{ $id }}'].dates.formatInput = date => moment(date).format('DD MMM yyyy HH:mm');
       document.addEventListener('datetime-clear', () => {
-        pickers['{{ $id }}'].dates.setValue(tempusDominus.DateTime.convert(new Date()));
+        pickers['{{ $id }}'].dates.setValue('{{ $id }}'.includes('end') ? tempusDominus.DateTime.convert(new Date()).manipulate(1, 'hours') : tempusDominus.DateTime.convert(new Date()));
       });
     "
 >


### PR DESCRIPTION
AB#{165}
We must set the initial loan start and end dates in both PHP and JS otherwise this will cause validation errors/numbers jumping around